### PR TITLE
feat: add marketplace webhook dispatch on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,3 +151,12 @@ jobs:
           generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify marketplace of new release
+        if: steps.bump.outputs.skip != 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MARKETPLACE_TOKEN }}
+          repository: robinmordasiewicz/f5-distributed-cloud-marketplace
+          event-type: plugin-release
+          client-payload: '{"plugin": "f5xc-console", "version": "${{ steps.bump.outputs.new_version }}"}'


### PR DESCRIPTION
## Summary

Add a step to the release workflow to notify the F5 Distributed Cloud marketplace when a new version is published. This enables automatic version synchronization.

## Changes

Added a new step after "Create GitHub Release" in `.github/workflows/release.yml` that uses `peter-evans/repository-dispatch@v3` to notify the marketplace.

## Prerequisites

The `MARKETPLACE_TOKEN` secret has already been configured with a fine-grained PAT that has write access to the marketplace repository.

## How it works

1. When a new release is created, this step dispatches an event to the marketplace
2. The marketplace's `plugin-sync.yml` workflow handles the event
3. The workflow fetches the latest npm metadata and updates documentation
4. Updated docs are automatically deployed to GitHub Pages

Closes #4

## Test plan

- [ ] Merge this PR
- [ ] Create a new release (e.g., commit a feat: change)
- [ ] Verify the marketplace receives the dispatch and updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
